### PR TITLE
Using non-root user again

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -167,7 +167,7 @@ RUN apt-get update && \
 # Create non-root user, add to root group
 RUN groupadd -g 999 backend_user && \
     useradd --create-home --system --uid 999 --gid root backend_user
-#USER backend_user
+USER backend_user
 
 # Set default directory to the log directory
 WORKDIR /var/backend/logs/

--- a/folding-stats-rest/src/main/java/me/zodac/folding/bean/Storage.java
+++ b/folding-stats-rest/src/main/java/me/zodac/folding/bean/Storage.java
@@ -84,7 +84,6 @@ public class Storage {
     private final TcStatsCache tcStatsCache = TcStatsCache.getInstance();
     private final TotalStatsCache totalStatsCache = TotalStatsCache.getInstance();
 
-
     /**
      * Creates a {@link Hardware}.
      *


### PR DESCRIPTION
Ran into an issue where the docker volume prior to the non-root user being introduced still had
root as the owner of the files. Needed to manually run 'chown' then was able to use the non-root
user without any problems.